### PR TITLE
Implement partner onboarding flow

### DIFF
--- a/app/(dashboard)/inventory/components/ai-search-bar.tsx
+++ b/app/(dashboard)/inventory/components/ai-search-bar.tsx
@@ -11,26 +11,44 @@ interface Props {
 export default function AiSearchBar({ onResults }: Props) {
   const [query, setQuery] = useState('')
   const [loading, setLoading] = useState(false)
+  const [status, setStatus] = useState('')
 
   const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault()
     setLoading(true)
-    const res = await fetch('/api/ai-search', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query })
-    })
-    const data = await res.json()
-    onResults(data)
+    setStatus('Buscando...')
+    try {
+      const res = await fetch('/api/ai-search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query })
+      })
+      const data = await res.json()
+      if (res.ok) {
+        onResults(data)
+        setStatus('')
+      } else {
+        setStatus('Error: ' + (data.error || ''))
+      }
+    } catch (e) {
+      setStatus('Error al buscar')
+    }
     setLoading(false)
   }
 
   return (
-    <form onSubmit={handleSearch} className="flex space-x-2">
-      <Input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Buscar productos..." />
-      <Button type="submit" disabled={loading}>
-        {loading ? 'Buscando...' : 'Buscar'}
-      </Button>
-    </form>
+    <div>
+      <form onSubmit={handleSearch} className="flex space-x-2">
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Buscar productos..."
+        />
+        <Button type="submit" disabled={loading}>
+          {loading ? 'Buscando...' : 'Buscar'}
+        </Button>
+      </form>
+      {status && <p className="text-sm mt-1">{status}</p>}
+    </div>
   )
 }

--- a/app/(dashboard)/inventory/page.tsx
+++ b/app/(dashboard)/inventory/page.tsx
@@ -5,19 +5,59 @@ import AiSearchBar from './components/ai-search-bar'
 
 export default function InventoryPage() {
   const [products, setProducts] = useState<any[]>([])
+  const [page, setPage] = useState(1)
+  const PER_PAGE = 10
+
+  const paginated = products.slice((page - 1) * PER_PAGE, page * PER_PAGE)
+  const totalPages = Math.ceil(products.length / PER_PAGE)
 
   return (
     <div>
-      <AiSearchBar onResults={setProducts} />
-      <div className="mt-4 grid grid-cols-1 gap-4">
-        {products.map((p) => (
-          <div key={p.id} className="border p-2 rounded">
-            <p className="font-semibold">{p.name}</p>
-            <p>{p.brand}</p>
-            <p>${p.price}</p>
-          </div>
-        ))}
-      </div>
+      <AiSearchBar
+        onResults={(data) => {
+          setProducts(data)
+          setPage(1)
+        }}
+      />
+      <table className="mt-4 w-full border text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border p-2 text-left">Nombre</th>
+            <th className="border p-2 text-left">Marca</th>
+            <th className="border p-2 text-left">Precio</th>
+          </tr>
+        </thead>
+        <tbody>
+          {paginated.map((p) => (
+            <tr key={p.id} className="border-b">
+              <td className="p-2">{p.name}</td>
+              <td className="p-2">{p.brand}</td>
+              <td className="p-2">${p.price}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {totalPages > 1 && (
+        <div className="mt-2 flex items-center space-x-2">
+          <button
+            className="px-2 py-1 border rounded"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+          >
+            Anterior
+          </button>
+          <span>
+            {page} / {totalPages}
+          </span>
+          <button
+            className="px-2 py-1 border rounded"
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+          >
+            Siguiente
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/(dashboard)/partners/components/excel-uploader.tsx
+++ b/app/(dashboard)/partners/components/excel-uploader.tsx
@@ -1,36 +1,108 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+const PRODUCT_FIELDS = [
+  'sku',
+  'name',
+  'description',
+  'brand',
+  'category',
+  'price',
+  'stock'
+]
 
 interface Props {
-  partnerId?: number
+  partnerId: number
+  existingMapping?: Record<string, string>
 }
 
-export default function ExcelUploader({ partnerId }: Props) {
+export default function ExcelUploader({ partnerId, existingMapping }: Props) {
   const [file, setFile] = useState<File | null>(null)
+  const [columns, setColumns] = useState<string[]>([])
+  const [mapping, setMapping] = useState<Record<string, string>>(
+    existingMapping || {}
+  )
   const [status, setStatus] = useState('')
+
+  const analyze = async () => {
+    if (!file) return
+    setStatus('Analizando archivo...')
+    const formData = new FormData()
+    formData.append('file', file)
+    const res = await fetch('/api/analyze-excel', {
+      method: 'POST',
+      body: formData
+    })
+    const data = await res.json()
+    if (res.ok) {
+      setColumns(data.columns || [])
+      setStatus('')
+    } else {
+      setStatus('Error: ' + (data.error || ''))
+    }
+  }
 
   const handleUpload = async () => {
     if (!file) return
-    setStatus('Cargando...')
+    setStatus('Subiendo archivo...')
     const formData = new FormData()
     formData.append('file', file)
-    if (partnerId) formData.append('partnerId', String(partnerId))
-    const res = await fetch('/api/upload-excel', { method: 'POST', body: formData })
+    formData.append('partnerId', String(partnerId))
+    formData.append('mapping', JSON.stringify(mapping))
+    const res = await fetch('/api/upload-excel', {
+      method: 'POST',
+      body: formData
+    })
+    const data = await res.json()
     if (res.ok) {
-      setStatus('Procesando archivo')
+      setStatus('¡Mapeo guardado!')
     } else {
-      setStatus('Error al subir')
+      setStatus('Error: ' + (data.error || ''))
     }
   }
 
   return (
-    <div className="space-x-2">
-      <Input type="file" accept=".xlsx" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-      <Button onClick={handleUpload}>Subir Excel</Button>
-      {status && <span className="ml-2 text-sm">{status}</span>}
+    <div className="space-y-2">
+      <div className="space-x-2">
+        <Input
+          type="file"
+          accept=".xlsx"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+        />
+        <Button type="button" onClick={analyze} disabled={!file}>
+          Analizar
+        </Button>
+      </div>
+      {columns.length > 0 && (
+        <div className="space-y-2">
+          {PRODUCT_FIELDS.map((field) => (
+            <div key={field} className="flex items-center space-x-2">
+              <label className="w-28 capitalize">{field}</label>
+              <select
+                className="border rounded px-2 py-1 flex-1"
+                value={mapping[field] || ''}
+                onChange={(e) =>
+                  setMapping({ ...mapping, [field]: e.target.value })
+                }
+              >
+                <option value="">Sin asignar</option>
+                {columns.map((col) => (
+                  <option key={col} value={col}>
+                    {col}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+          <Button type="button" onClick={handleUpload}>
+            Guardar y Cargar
+          </Button>
+        </div>
+      )}
+      {status && <p className="text-sm mt-1">{status}</p>}
     </div>
   )
 }

--- a/app/(dashboard)/partners/components/partners-client-page.tsx
+++ b/app/(dashboard)/partners/components/partners-client-page.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import ExcelUploader from './excel-uploader'
+
+interface Partner {
+  id: number
+  name: string
+}
+interface Mapping {
+  id: number
+  partner_id: number
+  mapping: Record<string, string>
+}
+
+interface Props {
+  partners: Partner[]
+  mappings: Mapping[]
+}
+
+export default function PartnersClientPage({ partners, mappings }: Props) {
+  const mappingByPartner: Record<number, Record<string, string>> = {}
+  mappings.forEach((m) => {
+    mappingByPartner[m.partner_id] = m.mapping
+  })
+
+  return (
+    <div className="space-y-4">
+      {partners.map((p) => (
+        <div key={p.id} className="border p-4 rounded space-y-2">
+          <h3 className="font-semibold text-lg">{p.name}</h3>
+          <ExcelUploader
+            partnerId={p.id}
+            existingMapping={mappingByPartner[p.id]}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/(dashboard)/partners/page.tsx
+++ b/app/(dashboard)/partners/page.tsx
@@ -1,28 +1,18 @@
-'use client'
+import PartnersClientPage from './components/partners-client-page'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
 
-import { useEffect, useState } from 'react'
-import ExcelUploader from './components/excel-uploader'
-import { supabase } from '@/lib/supabase'
+export default async function PartnersPage() {
+  const supabase = createSupabaseServerClient()
+  const { data: partners } = await supabase
+    .from('business_partners')
+    .select('*')
+    .eq('type', 'supplier')
 
-export default function PartnersPage() {
-  const [partners, setPartners] = useState<any[]>([])
-
-  useEffect(() => {
-    supabase.from('business_partners').select('*').then(({ data }) => {
-      if (data) setPartners(data)
-    })
-  }, [])
+  const { data: mappings } = await supabase
+    .from('data_source_mappings')
+    .select('*')
 
   return (
-    <div className="space-y-4">
-      <ul className="list-disc pl-5 space-y-2">
-        {partners.map((p) => (
-          <li key={p.id} className="space-y-1">
-            <span className="font-semibold">{p.name}</span>
-            <ExcelUploader partnerId={p.id} />
-          </li>
-        ))}
-      </ul>
-    </div>
+    <PartnersClientPage partners={partners || []} mappings={mappings || []} />
   )
 }

--- a/app/api/ai-search/route.ts
+++ b/app/api/ai-search/route.ts
@@ -6,7 +6,19 @@ export async function POST(req: Request) {
   const { query } = await req.json()
   if (!query) return NextResponse.json([], { status: 400 })
 
-  const prompt = `Eres un asistente de base de datos. Convierte la siguiente consulta de usuario para una óptica en un objeto JSON con los campos posibles: brand, category, minPrice, maxPrice, attributes. Responde solo con el JSON. Consulta: "${query}"`
+  const { data: brandRows } = await supabase.from('products').select('brand')
+  const { data: categoryRows } = await supabase
+    .from('products')
+    .select('category')
+
+  const brands = Array.from(
+    new Set((brandRows || []).map((r) => r.brand).filter(Boolean))
+  )
+  const categories = Array.from(
+    new Set((categoryRows || []).map((r) => r.category).filter(Boolean))
+  )
+
+  const prompt = `Eres un asistente de base de datos. Usa solo las siguientes marcas: ${brands.join(', ')} y las siguientes categorias: ${categories.join(', ')}. Convierte la siguiente consulta del usuario en un objeto JSON con los campos posibles: brand, category, minPrice, maxPrice, attributes. Responde solo con el JSON. Consulta: "${query}"`
 
   const completion = await openai.chat.completions.create({
     model: 'gpt-4o',

--- a/app/api/analyze-excel/route.ts
+++ b/app/api/analyze-excel/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { read, utils } from 'xlsx'
+
+export async function POST(req: Request) {
+  const formData = await req.formData()
+  const file = formData.get('file') as File | null
+
+  if (!file) {
+    return NextResponse.json({ error: 'Falta el archivo.' }, { status: 400 })
+  }
+
+  try {
+    const buffer = await file.arrayBuffer()
+    const workbook = read(buffer)
+    const sheet = workbook.Sheets[workbook.SheetNames[0]]
+    const rows: any[][] = utils.sheet_to_json(sheet, { header: 1 })
+    const header = rows[0]
+    const columns = Array.isArray(header)
+      ? header.map((c) => String(c))
+      : Object.keys(utils.sheet_to_json(sheet)[0] || {})
+    return NextResponse.json({ columns })
+  } catch (e) {
+    return NextResponse.json(
+      { error: 'No se pudo leer el archivo.' },
+      { status: 400 }
+    )
+  }
+}

--- a/database.sql
+++ b/database.sql
@@ -104,13 +104,13 @@ CREATE TABLE data_sources (
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
--- Mapeo de columnas por fuente de datos
+-- Recetas de mapeo por socio comercial
 CREATE TABLE data_source_mappings (
-  id SERIAL PRIMARY KEY,
-  data_source_id BIGINT NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
-  source_column TEXT NOT NULL,
-  target_field TEXT NOT NULL,
-  source_type TEXT NOT NULL DEFAULT 'excel'
+  id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  partner_id BIGINT NOT NULL UNIQUE REFERENCES business_partners(id) ON DELETE CASCADE,
+  mapping JSONB NOT NULL,
+  source_type TEXT NOT NULL DEFAULT 'excel',
+  created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
 -- Relaciones jerárquicas entre socios


### PR DESCRIPTION
## Summary
- remove old supplier pages
- migrate onboarding to generalized partner model
- store mapping recipes in `data_source_mappings`
- update Excel upload API to save mappings per partner
- simplify dashboard navigation

## Testing
- `npm install`
- `npm run lint` *(fails: Next.js prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68689c670f308331aa7a4434b67cca94